### PR TITLE
Resolve Meson-UI subprojects dialog

### DIFF
--- a/data/mesonui-layout/activity_subprojects.ui
+++ b/data/mesonui-layout/activity_subprojects.ui
@@ -47,7 +47,7 @@
    <property name="title">
     <string>Subprojects view:</string>
    </property>
-   <widget class="QLabel" name="label_5">
+   <widget class="QLabel" name="logo">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -122,7 +122,7 @@
      <rect>
       <x>120</x>
       <y>100</y>
-      <width>601</width>
+      <width>261</width>
       <height>21</height>
      </rect>
     </property>
@@ -130,7 +130,7 @@
      <string>   subproject name here</string>
     </property>
    </widget>
-   <widget class="QLabel" name="label">
+   <widget class="QLabel" name="label_subprojects">
     <property name="geometry">
      <rect>
       <x>20</x>
@@ -196,6 +196,32 @@
       <string/>
      </property>
     </widget>
+   </widget>
+   <widget class="QLineEdit" name="entry_branch_item">
+    <property name="geometry">
+     <rect>
+      <x>500</x>
+      <y>100</y>
+      <width>221</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="placeholderText">
+     <string>   branch name here</string>
+    </property>
+   </widget>
+   <widget class="QLabel" name="label_branch">
+    <property name="geometry">
+     <rect>
+      <x>400</x>
+      <y>100</y>
+      <width>101</width>
+      <height>21</height>
+     </rect>
+    </property>
+    <property name="text">
+     <string>branch name:</string>
+    </property>
    </widget>
   </widget>
  </widget>

--- a/mesonui/mesonuilib/mesonbuild/subprojects.py
+++ b/mesonui/mesonuilib/mesonbuild/subprojects.py
@@ -16,20 +16,17 @@ class MesonSubprojects:
         self._sourcedir: Path = sourcedir
         super().__init__()
 
-    def update(self, args):
-        run_cmd = ['meson', 'subprojects', 'update', '--sourcedir', str(self._sourcedir)]
-        run_cmd.extend(args)
+    def update(self, subproject):
+        run_cmd = ['meson', 'subprojects', 'update', subproject, '--sourcedir', str(self._sourcedir)]
         process = subprocess.Popen(run_cmd, encoding='utf8', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return process.communicate()[0]
 
-    def checkout(self, args):
-        run_cmd = ['meson', 'subprojects', 'checkout', '--sourcedir', str(self._sourcedir)]
-        run_cmd.extend(args)
+    def checkout(self, branch: str, subproject):
+        run_cmd = ['meson', 'subprojects', 'checkout', branch, subproject, '--sourcedir', str(self._sourcedir)]
         process = subprocess.Popen(run_cmd, encoding='utf8', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return process.communicate()[0]
 
-    def download(self, args):
-        run_cmd = ['meson', 'subprojects', 'download', '--sourcedir', str(self._sourcedir)]
-        run_cmd.extend(args)
+    def download(self, subproject):
+        run_cmd = ['meson', 'subprojects', 'download', subproject, '--sourcedir', str(self._sourcedir)]
         process = subprocess.Popen(run_cmd, encoding='utf8', stdout=subprocess.PIPE, stderr=subprocess.PIPE)
         return process.communicate()[0]

--- a/mesonui/models/testlogslist.py
+++ b/mesonui/models/testlogslist.py
@@ -20,7 +20,7 @@ class TestsLogsModel:
 
     def set_list(self, value) -> None:
         options = value.get_object(group='tests')
-        testlog = value.get_object(group='testlog', extract_method='loader')
+        testlog = value.get_object(group='testlog')
         if options is None or testlog is None:
             return
 

--- a/mesonui/ui/activity_subprojects.py
+++ b/mesonui/ui/activity_subprojects.py
@@ -2,7 +2,7 @@
 
 # Form implementation generated from reading ui file 'data/mesonui-layout/activity_subprojects.ui'
 #
-# Created by: PyQt5 UI code generator 5.14.0
+# Created by: PyQt5 UI code generator 5.13.1
 #
 # WARNING! All changes made in this file will be lost!
 
@@ -10,7 +10,7 @@
 from PyQt5 import QtCore, QtGui, QtWidgets
 
 
-class Ui_Activity_Wrap_Dialog:
+class Ui_Activity_Wrap_Dialog(object):
     def setupUi(self, Activity_Wrap_Dialog):
         Activity_Wrap_Dialog.setObjectName("Activity_Wrap_Dialog")
         Activity_Wrap_Dialog.resize(741, 422)
@@ -23,14 +23,14 @@ class Ui_Activity_Wrap_Dialog:
         self.groupBox.setGeometry(QtCore.QRect(0, 0, 741, 361))
         self.groupBox.setStyleSheet("")
         self.groupBox.setObjectName("groupBox")
-        self.label_5 = QtWidgets.QLabel(self.groupBox)
-        self.label_5.setGeometry(QtCore.QRect(20, 30, 81, 71))
-        self.label_5.setAutoFillBackground(False)
-        self.label_5.setStyleSheet("")
-        self.label_5.setText("")
-        self.label_5.setPixmap(QtGui.QPixmap(":/icon/mesonui-icon/meson_modern.png"))
-        self.label_5.setScaledContents(True)
-        self.label_5.setObjectName("label_5")
+        self.logo = QtWidgets.QLabel(self.groupBox)
+        self.logo.setGeometry(QtCore.QRect(20, 30, 81, 71))
+        self.logo.setAutoFillBackground(False)
+        self.logo.setStyleSheet("")
+        self.logo.setText("")
+        self.logo.setPixmap(QtGui.QPixmap(":/icon/mesonui-icon/meson_modern.png"))
+        self.logo.setScaledContents(True)
+        self.logo.setObjectName("logo")
         self.layoutWidget = QtWidgets.QWidget(self.groupBox)
         self.layoutWidget.setGeometry(QtCore.QRect(20, 130, 701, 32))
         self.layoutWidget.setStyleSheet("")
@@ -51,11 +51,11 @@ class Ui_Activity_Wrap_Dialog:
         self.control_push_checkout.setObjectName("control_push_checkout")
         self.horizontalLayout.addWidget(self.control_push_checkout)
         self.entry_subproject_item = QtWidgets.QLineEdit(self.groupBox)
-        self.entry_subproject_item.setGeometry(QtCore.QRect(120, 100, 601, 21))
+        self.entry_subproject_item.setGeometry(QtCore.QRect(120, 100, 261, 21))
         self.entry_subproject_item.setObjectName("entry_subproject_item")
-        self.label = QtWidgets.QLabel(self.groupBox)
-        self.label.setGeometry(QtCore.QRect(20, 100, 101, 21))
-        self.label.setObjectName("label")
+        self.label_subprojects = QtWidgets.QLabel(self.groupBox)
+        self.label_subprojects.setGeometry(QtCore.QRect(20, 100, 101, 21))
+        self.label_subprojects.setObjectName("label_subprojects")
         self.info = QtWidgets.QPlainTextEdit(self.groupBox)
         self.info.setGeometry(QtCore.QRect(120, 30, 601, 61))
         self.info.setStyleSheet("")
@@ -71,6 +71,12 @@ class Ui_Activity_Wrap_Dialog:
         self.output_console.setReadOnly(True)
         self.output_console.setPlainText("")
         self.output_console.setObjectName("output_console")
+        self.entry_branch_item = QtWidgets.QLineEdit(self.groupBox)
+        self.entry_branch_item.setGeometry(QtCore.QRect(500, 100, 221, 21))
+        self.entry_branch_item.setObjectName("entry_branch_item")
+        self.label_branch = QtWidgets.QLabel(self.groupBox)
+        self.label_branch.setGeometry(QtCore.QRect(400, 100, 101, 21))
+        self.label_branch.setObjectName("label_branch")
 
         self.retranslateUi(Activity_Wrap_Dialog)
         QtCore.QMetaObject.connectSlotsByName(Activity_Wrap_Dialog)
@@ -84,8 +90,10 @@ class Ui_Activity_Wrap_Dialog:
         self.control_push_update.setText(_translate("Activity_Wrap_Dialog", "Update"))
         self.control_push_checkout.setText(_translate("Activity_Wrap_Dialog", "Checkout"))
         self.entry_subproject_item.setPlaceholderText(_translate("Activity_Wrap_Dialog", "   subproject name here"))
-        self.label.setText(_translate("Activity_Wrap_Dialog", "subproject:"))
+        self.label_subprojects.setText(_translate("Activity_Wrap_Dialog", "subproject:"))
         self.info.setPlainText(_translate("Activity_Wrap_Dialog", "Subprojects is a subcommand of Meson that allows you to manage your source dependencies."))
         self.output_console_dashboard.setTitle(_translate("Activity_Wrap_Dialog", "Output Console:"))
+        self.entry_branch_item.setPlaceholderText(_translate("Activity_Wrap_Dialog", "   branch name here"))
+        self.label_branch.setText(_translate("Activity_Wrap_Dialog", "branch name:"))
 
 from . import resource_rc

--- a/mesonui/view/subprojects_activity.py
+++ b/mesonui/view/subprojects_activity.py
@@ -45,15 +45,16 @@ class SubprojectsActivity(QDialog, Ui_Activity_Wrap_Dialog):
 
     @pyqtSlot()
     def exec_download(self):
-        self.console.command_run(self._model.buildsystem().meson().subprojects().download([self.edit_wrap_item.text()]))
+        self.console.command_run(self._model.buildsystem().meson().subprojects().download(self.edit_wrap_item.text()))
 
     @pyqtSlot()
     def exec_checkout(self):
-        self.console.command_run(self._model.buildsystem().meson().subprojects().checkout([self.edit_wrap_item.text()]))
+        self.console.command_run(
+            self._model.buildsystem().meson().subprojects().checkout(self.entry_branch_item.text(), self.edit_wrap_item.text()))
 
     @pyqtSlot()
     def exec_update(self):
-        self.console.command_run(self._model.buildsystem().meson().subprojects().update([self.edit_wrap_item.text()]))
+        self.console.command_run(self._model.buildsystem().meson().subprojects().update(self.edit_wrap_item.text()))
 
     @pyqtSlot()
     def exec_ok(self):

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -213,6 +213,7 @@ class TestMeson:
         meson.init(['--language=c', '--type=executable'])
         meson.setup(['--backend=ninja'])
         meson.compile()
+        meson.install()
 
         #
         # Run asserts to check it is working

--- a/run_project_tests.py
+++ b/run_project_tests.py
@@ -14,12 +14,26 @@ from mesonui.packageinfo import PackageInfo
 from mesonui.projectinfo import ProjectInfo
 from mesonui.authorinfo import ProjectAuthor
 from mesonui.mesonuilib.buildsystem import Meson
+from os.path import join as join_paths
 import shutil
 import logging
+import os
 
 logger = logging.getLogger(__name__)
 sublogger = logging.getLogger(__name__ + ".log")
 
+TEST_WRAP: str = '''\
+[wrap-file]
+directory = sqlite-amalgamation-3080802
+
+source_url = http://sqlite.com/2015/sqlite-amalgamation-3080802.zip
+source_filename = sqlite-amalgamation-3080802.zip
+source_hash = 5ebeea0dfb75d090ea0e7ff84799b2a7a1550db3fe61eb5f6f61c2e971e57663
+
+patch_url = https://wrapdb.mesonbuild.com/v1/projects/sqlite/3080802/5/get_zip
+patch_filename = sqlite-3080802-5-wrap.zip
+patch_hash = d66469a73fa1344562d56a1d7627d5d0ee4044a77b32d16cf4bbb85741d4c9fd
+'''
 
 class TestPyPiPackageInfo:
     def test_all_pypi_info(self):
@@ -275,6 +289,82 @@ class TestMeson:
         assert tmpdir.join('meson.build').ensure()
         assert tmpdir.join('builddir', 'build.ninja').ensure()
         assert tmpdir.join('builddir', 'compile_commands.json').ensure()
+
+    @pytest.mark.skipif(not shutil.which('git'), reason='Did not find "git" on this system')
+    def test_subproject_checkout_subcommand(self, tmpdir):
+        #
+        # Setting up tmp test directory
+        with tmpdir.as_cwd():
+            pass
+        tmpdir.chdir()
+
+        #
+        # Running Meson command
+        meson: Meson = Meson(sourcedir=tmpdir, builddir=(tmpdir / 'builddir'))
+        meson.init(['--language=c', '--deps', 'samplesubproject'])
+        os.mkdir('subprojects')
+
+        tmpdir.join(join_paths('subprojects', 'samplesubproject.wrap')).write('''\
+        [wrap-git]
+        directory=samplesubproject
+        url=https://github.com/jpakkane/samplesubproject.git
+        revision=head
+        ''')
+
+        meson.subprojects().download('samplesubproject')
+        meson.subprojects().checkout('master', 'samplesubproject')
+
+        #
+        # Run asserts to check it is working
+        assert tmpdir.join('meson.build').ensure()
+        assert tmpdir.join('subprojects', 'samplesubproject.wrap').ensure()
+        assert tmpdir.join('subprojects', 'samplesubproject', '.gitignore').ensure()
+        assert tmpdir.join('subprojects', 'samplesubproject', 'README.md').ensure()
+
+    def test_subproject_update_subcommand(self, tmpdir):
+        #
+        # Setting up tmp test directory
+        with tmpdir.as_cwd():
+            pass
+        tmpdir.chdir()
+
+        #
+        # Running Meson command
+        meson: Meson = Meson(sourcedir=tmpdir, builddir=(tmpdir / 'builddir'))
+        meson.init(['--language=c', '--deps', 'sqlite'])
+        os.mkdir('subprojects')
+
+        tmpdir.join(join_paths('subprojects', 'sqlite.wrap')).write(TEST_WRAP)
+
+        meson.subprojects().download('sqlite')
+        meson.subprojects().update('sqlite')
+
+        #
+        # Run asserts to check it is working
+        assert tmpdir.join('meson.build').ensure()
+        assert tmpdir.join('subprojects', 'sqlite.wrap').ensure()
+
+    def test_subproject_download_subcommand(self, tmpdir):
+        #
+        # Setting up tmp test directory
+        with tmpdir.as_cwd():
+            pass
+        tmpdir.chdir()
+
+        #
+        # Running Meson command
+        meson: Meson = Meson(sourcedir=tmpdir, builddir=(tmpdir / 'builddir'))
+        meson.init(['--language=c', '--deps', 'sqlite'])
+        os.mkdir('subprojects')
+
+        tmpdir.join(join_paths('subprojects', 'sqlite.wrap')).write(TEST_WRAP)
+
+        meson.subprojects().download('sqlite')
+
+        #
+        # Run asserts to check it is working
+        assert tmpdir.join('meson.build').ensure()
+        assert tmpdir.join('subprojects', 'sqlite.wrap').ensure()
 
 
 class TestMesonBackend:

--- a/run_unittests.py
+++ b/run_unittests.py
@@ -272,6 +272,17 @@ class TestMesonAPI:
 
         assert(info is None)
 
+    def test_meson_api_scanner_testlogs_get_none(self):
+        source = join('test-cases', 'meson-api', '11-scan-testlog-null')
+        build = join('test-cases', 'meson-api', '11-scan-testlog-null', 'builddir')
+
+        script: MesonAPI = MesonAPI(sourcedir=source, builddir=build)
+        #
+        # Posable value of passing testlog will be None
+        info = script.get_object(group='testlog', extract_method='script')
+
+        assert(info is None)
+
     def test_meson_api_bad_extract_method(self):
         reader: MesonAPI = MesonAPI(None, None)
         with pytest.raises(Exception) as e:

--- a/test-cases/meson-api/11-scan-testlog-null/empty.txt
+++ b/test-cases/meson-api/11-scan-testlog-null/empty.txt
@@ -1,0 +1,1 @@
+empty file with no Meson build should make the full back return None


### PR DESCRIPTION
This PR resolves issues with Meson subprojects command being improperly implemented, also adds missing test case for when Meson api loader fails to find `testlog.json`.